### PR TITLE
Fixing the ordering bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispose-me",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Dispose Me is a simple AWS-hosted disposable email service.",
   "author": "Kamil Dybicz",
   "license": "MIT",

--- a/service/api/InboxController.ts
+++ b/service/api/InboxController.ts
@@ -107,12 +107,12 @@ export class InboxController {
       this.bucketName,
       normalizedUsername,
       listEmailsAfter,
-      1000,
+      1,
     );
 
     let email: Email | undefined;
     if (emailsList.KeyCount !== 0) {
-      const latestFilePath = emailsList.Contents?.slice(-1).pop()?.Key;
+      const latestFilePath = emailsList.Contents?.pop()?.Key;
 
       if (latestFilePath) {
         const latestEmail = await this.fileSystem.getObject(this.bucketName, latestFilePath);
@@ -185,10 +185,10 @@ export class InboxController {
 
     if (type === 'html') {
       const token = this.getToken(req);
-      return res.render('pages/list', { emails: emails.reverse(), token });
+      return res.render('pages/list', { emails, token });
     }
 
-    return res.json({ emails: emails.reverse() });
+    return res.json({ emails });
   }
 
   render403Response(req: Request, res: Response): void {

--- a/service/processor/IncomingEmailProcessor.ts
+++ b/service/processor/IncomingEmailProcessor.ts
@@ -3,6 +3,8 @@ import type { S3FileSystem } from '../tools/S3FileSystem';
 import log from '../tools/log';
 import { normalizeUsername } from '../tools/utils';
 
+const MAX_EPOCH = 9999999999999;
+
 export class IncomingEmailProcessor {
   protected fileSystem: S3FileSystem;
 
@@ -50,7 +52,8 @@ export class IncomingEmailProcessor {
       }
 
       const copyToUserInboxTasks = [...uniqueNormalizedUsernames].map((normalizedUsername) => {
-        const targetFile = `${normalizedUsername}/${emailContent.received.getTime()}`;
+        const filename = `${MAX_EPOCH - emailContent.received.getTime()}.eml`;
+        const targetFile = `${normalizedUsername}/${filename}`;
 
         return this.fileSystem.copyObject(this.bucketName, messageId, targetFile);
       });

--- a/test/service/processor/IncomingEmailHandler.test.ts
+++ b/test/service/processor/IncomingEmailHandler.test.ts
@@ -34,7 +34,7 @@ describe('EmailParser tests', () => {
     await processor.processEmail(MESSAGE_ID);
     // then:
     expect(fileSystem.copyObject).toHaveBeenCalledTimes(1);
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/1483900664000');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/8516099335999.eml');
     // and:
     expect(fileSystem.deleteObject).toHaveBeenCalledTimes(1);
   });
@@ -53,8 +53,8 @@ describe('EmailParser tests', () => {
     await processor.processEmail(MESSAGE_ID);
     // then:
     expect(fileSystem.copyObject).toHaveBeenCalledTimes(2);
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'johndoe/1476358788000');
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/1476358788000');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'johndoe/8523641211999.eml');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/8523641211999.eml');
     // and:
     expect(fileSystem.deleteObject).toHaveBeenCalledTimes(1);
   });
@@ -73,8 +73,8 @@ describe('EmailParser tests', () => {
     await processor.processEmail(MESSAGE_ID);
     // then:
     expect(fileSystem.copyObject).toHaveBeenCalledTimes(2);
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/1644425711000');
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'mariadoe/1644425711000');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'janedoe/8355574288999.eml');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'mariadoe/8355574288999.eml');
     // and:
     expect(fileSystem.deleteObject).toHaveBeenCalledTimes(1);
   });
@@ -93,7 +93,7 @@ describe('EmailParser tests', () => {
     await processor.processEmail(MESSAGE_ID);
     // then:
     expect(fileSystem.copyObject).toHaveBeenCalledTimes(1);
-    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'hidden/1644425711000');
+    expect(fileSystem.copyObject).toHaveBeenCalledWith(EMAIL_BUCKET_NAME, MESSAGE_ID, 'hidden/8355574288999.eml');
     // and:
     expect(fileSystem.deleteObject).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## 💡 What's Changed

Fixing a bug where if there were more emails in the Inbox than the `limit` (default: 10), only X oldest emails were shown.