### PR TITLE
Improving api endpoints

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,18 @@ Dispose Me is a simple AWS-hosted disposable email service.
 - Simple Storage Service
 
 
+## API Documentation
+
+You can find the full OpenAPI (Swagger) schema for the Dispose Me API in the repository:
+
+- **Schema file:** [`docs/schema.yaml`](docs/schema.yaml)
+
+You can also view and explore the API interactively using the online Swagger UI:
+
+- **Online schema viewer:**  
+  [https://petstore.swagger.io/?url=https://raw.githubusercontent.com/kdybicz/dispose-me/refs/heads/master/docs/schema.yaml](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/kdybicz/dispose-me/refs/heads/master/docs/schema.yaml)
+
+
 ## Setup process
 
 ### Environment

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -4,6 +4,20 @@ info:
   title: Dispose Me
   description: |-
     Dispose Me is a simple AWS-hosted disposable email service with API capabilities.
+
+    ### Authentication
+    An API token is required for all endpoints. For flexibility, users can provide the token in **one** of three ways:
+      - HTTP Header: `x-api-key`
+      - Query Parameter: `x-api-key`
+      - Cookie: `x-api-key`
+    Choose whichever method best suits your use case.
+  contact:
+    name: Dispose Me Maintainers
+    url: https://github.com/kdybicz/dispose-me
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
 servers:
   - url: https://{hostname}
     variables:
@@ -20,12 +34,13 @@ paths:
     get:
       summary: List emails in the inbox
       description: List all emails sent to the inbox for a given username.
+      operationId: listInboxEmails
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
@@ -34,19 +49,20 @@ paths:
             maxLength: 25
         - name: type
           in: query
-          description: Output format
+          description: Response output format.
           schema:
             type: string
             enum: ["json", "html"]
             default: "html"
         - name: sentAfter
           in: query
-          description: Show only emails send after a date, represented as a Unix epoch time, with seconds precision.
+          description: Show only emails sent after this Unix epoch time (seconds).
           schema:
             type: integer
+            format: int64
         - name: limit
           in: query
-          description: Change maximal number of shown messages
+          description: Maximum number of messages to return.
           schema:
             type: integer
             minimum: 0
@@ -54,15 +70,19 @@ paths:
             default: 10
       responses:
         '200':
-          description: Return list of emails in the inbox
+          description: Returns the list of emails in the inbox.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailList'
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
@@ -75,47 +95,52 @@ paths:
   /inbox/{username}/{id}:
     get:
       summary: Show details of an email
-      description: Show the content of the email, including author, all recipients, subject, body, and information about attachments.
+      description: Returns the content of an email, including author, recipients, subject, body, and attachment information.
+      operationId: getEmailDetails
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
             pattern: ^[a-zA-Z0-9.\-_+]*$
         - name: id
           in: path
-          description: Email ID
+          description: Unique identifier for the email.
           required: true
           schema:
             type: string
         - name: type
           in: query
-          description: Output format
+          description: Response output format.
           schema:
             type: string
             enum: ["json", "html"]
             default: "html"
       responses:
         '200':
-          description: Show email details
+          description: Returns email details.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailDetails'
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
-          description: Email with given ID not found
+          description: Email with the given ID was not found.
           content: 
             application/json: 
               schema: 
                 $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
@@ -127,55 +152,74 @@ paths:
 
   /inbox/{username}/{id}/attachment:
     get:
-      summary: Download given attachment
-      description: Allows to download an attachment.
+      summary: Download a specific attachment from an email
+      description: |
+        Download an attachment from the specified email.
+        The `Content-Type` header will match the attachment's MIME type (e.g., `image/png`, `application/pdf`, etc.).
+        The `Content-Disposition` header is set for proper file downloads.
+      operationId: downloadEmailAttachment
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
             pattern: ^[a-zA-Z0-9.\-_+]*$
         - name: id
           in: path
-          description: Email ID
+          description: Unique identifier for the email.
           required: true
           schema:
             type: string
         - name: filename
           in: query
-          description: Filename of the attachment
+          description: The filename of the attachment to download.
           required: true
           schema:
             type: string
             examples: ["image.png"]
       responses:
         '200':
-          description: Returns the attachment data
+          description: The attachment file data.
+          headers:
+            Content-Type:
+              description: The MIME type of the file.
+              schema:
+                type: string
+                examples: ["image/png"]
+            Content-Disposition:
+              description: Suggests a default filename for saving.
+              schema:
+                type: string
+                examples: ['attachment; filename="image.png"']
           content:
             "*/*":
               schema:
                 type: string
                 format: binary
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
-          description: Email with given ID not found
+          description: Email with the given ID was not found.
           content: 
             application/json: 
               schema: 
                 $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
         '500':
-          description: Invalid email content or missing attachment
+          description: Invalid email content or missing attachment.
           content: 
             application/json: 
               schema: 
@@ -187,37 +231,42 @@ paths:
 
   /inbox/{username}/{id}/delete:
     delete:
-      summary: Delete given email
-      description: Allows to delete the email with given ID.
+      summary: Delete a specific email
+      description: Deletes the email with the specified ID from the inbox.
+      operationId: deleteEmail
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
             pattern: ^[a-zA-Z0-9.\-_+]*$
         - name: id
           in: path
-          description: Email ID
+          description: Unique identifier for the email.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: Email successfully deleted
+          description: Email successfully deleted. No content is returned.
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
-          description: Email with given ID not found
+          description: Email with the given ID was not found.
           content: 
             application/json: 
               schema: 
                 $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
@@ -229,45 +278,64 @@ paths:
 
   /inbox/{username}/{id}/download:
     get:
-      summary: Download given email
-      description: Allows to download the email as an `.eml` file.
+      summary: Download an email as an `.eml` file
+      description: Download the full email as a standard `.eml` file.
+      operationId: downloadEmailAsEml
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
             pattern: ^[a-zA-Z0-9.\-_+]*$
         - name: id
           in: path
-          description: Email ID
+          description: Unique identifier for the email.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Returns the content of the email
+          description: The email content as an `.eml` file.
+          headers:
+            Content-Type:
+              description: The MIME type of the file `application/octet-stream`.
+              schema:
+                type: string
+                examples: ["application/octet-stream"]
+            Content-Disposition:
+              description: Suggests a default filename for saving.
+              schema:
+                type: string
+                examples: ['attachment; filename="email.eml"']
           content:
-            application/octet-stream: {}
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
-          description: Email with given ID not found
+          description: Email with the given ID was not found.
           content: 
             application/json: 
               schema: 
                 $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
         '500':
-          description: Invalid email content
+          description: Invalid email content.
           content: 
             application/json: 
               schema: 
@@ -280,40 +348,46 @@ paths:
   /inbox/{username}/latest:
     get:
       summary: Show details of the latest email
-      description: Show the content of the latest email, including author, all recipients, subject, body, and information about attachments.
+      description: Returns the content of the latest email, including author, recipients, subject, body, and attachment information.
+      operationId: getLatestEmail
       tags:
         - Inbox
       parameters:
         - name: username
           in: path
-          description: The username
+          description: The username associated with the disposable inbox.
           required: true
           schema:
             type: string
             pattern: ^[a-zA-Z0-9.\-_+]*$
         - name: sentAfter
           in: query
-          description: Show only email if it was send after a date, represented as a Unix epoch time, with seconds precision.
+          description: Show only the latest email if it was sent after this Unix epoch time (seconds).
           schema:
             type: integer
+            format: int64
         - name: type
           in: query
-          description: Output format
+          description: Response output format.
           schema:
             type: string
             enum: ["json", "html"]
             default: "html"
       responses:
         '200':
-          description: Show email details
+          description: Returns the details of the latest email.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailDetails'
         '403':
-          description: Forbidden
+          description: Forbidden – Invalid or missing API token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '422':
-          description: Invalid parameters
+          description: Invalid parameters.
           content:
             application/json:
               schema:
@@ -336,19 +410,24 @@ components:
       properties:
         id:
           type: string
+          description: Unique identifier for the email.
           examples: ["223pfcdcrjar5jukmha0s67k7bdn1l1gidasbuo1"]
         from:
           type: string
           format: email
+          description: Sender's email address.
           examples: ["jane.doe@example.com"]
         subject:
           type: string
+          description: Subject of the email.
           examples: ["Subject of the email"]
         received:
           type: string
           format: date-time
+          description: The timestamp when the email was received (RFC 3339 format).
         hasAttachments:
           type: boolean
+          description: Indicates if the email has any attachments.
           examples: [false]
     EmailList:
       type: object
@@ -357,6 +436,7 @@ components:
       properties:
         emails:
           type: array
+          description: Array of email items in the inbox.
           items: 
             $ref: '#/components/schemas/EmailItem'
     EmailAddress:
@@ -369,16 +449,20 @@ components:
         address:
           type: string
           format: email
+          description: Full email address (e.g., user@domain.com).
           examples: ["john.doe@example.com"]
         user:
           type: string
+          description: Local part of the email address (before @).
           examples: ["john.doe"]
         host:
           type: string
           format: hostname
+          description: Domain part of the email address.
           examples: ["example.com"]
         displayName:
           type: string
+          description: Display name of the sender or recipient.
           examples: ["John Doe"]
     Attachment:
       type: object
@@ -389,12 +473,15 @@ components:
       properties:
         filename:
           type: string
+          description: Name of the attachment file.
           examples: ["image.png"]
         size:
           type: integer
+          description: File size in bytes.
           examples: [1337]
         contentType:
           type: string
+          description: MIME type of the attachment file.
           examples: ["image/png"]
     EmailDetails:
       type: object
@@ -413,33 +500,39 @@ components:
           $ref: '#/components/schemas/EmailAddress'
         to:
           type: array
+          description: List of primary recipient email addresses.
           items:
             $ref: '#/components/schemas/EmailAddress'
         cc:
           type: array
+          description: List of CC recipient email addresses.
           items:
             $ref: '#/components/schemas/EmailAddress'
         bcc:
           type: array
+          description: List of BCC recipient email addresses.
           items:
             $ref: '#/components/schemas/EmailAddress'
         subject:
           type: string
-          description: Subject of the email
+          description: Subject of the email.
           examples: ["Subject of the email"]
         body:
           type: string
-          description: Body of the email
+          description: Body content of the email.
           examples: ["Body of the email"]
         received:
           type: string
           format: date-time
+          description: The timestamp when the email was received (RFC 3339 format).
         attachments:
           type: array
+          description: List of attachments for the email.
           items:
             $ref: '#/components/schemas/Attachment'
         id:
           type: string
+          description: Unique identifier for the email.
           examples: ["223pfcdcrjar5jukmha0s67k7bdn1l1gidasbuo1"]
     Error:
       type: object
@@ -448,6 +541,7 @@ components:
       properties:
         message:
           type: string
+          description: Error message.
           examples: ["The page you are looking for was not found."]
     ValidationError:
       type: object
@@ -456,6 +550,7 @@ components:
       properties:
         errors:
           type: array
+          description: List of validation errors.
           items:
             type: object
             required:
@@ -467,18 +562,23 @@ components:
             properties:
               type:
                 type: string
+                description: Type of error (e.g., "field").
                 examples: ["field"]
               value:
                 type: string
+                description: Invalid value provided by the client.
                 examples: ["user^name"]
               msg:
                 type: string
+                description: Error message explaining the validation failure.
                 examples: ["Username may only contain letters, numbers, dots (.), hyphens (-), underscores (_), and plus signs (+)."]
               path:
                 type: string
+                description: The name of the field that failed validation.
                 examples: ["username"]
               location:
                 type: string
+                description: Location of the parameter (e.g., "params", "query").
                 examples: ["params"]
 
   securitySchemes:
@@ -486,11 +586,14 @@ components:
       type: apiKey
       name: x-api-key
       in: header
+      description: API key to authorize requests, sent in HTTP header.
     api_token_query:
       type: apiKey
       name: x-api-key
       in: query
+      description: API key to authorize requests, sent as a query parameter.
     api_token_cookie:
       type: apiKey
       name: x-api-key
       in: cookie
+      description: API key to authorize requests, sent in a cookie.

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -186,7 +186,7 @@ paths:
         - api_token_cookie: []
 
   /inbox/{username}/{id}/delete:
-    get:
+    delete:
       summary: Delete given email
       description: Allows to delete the email with given ID.
       tags:
@@ -206,7 +206,7 @@ paths:
           schema:
             type: string
       responses:
-        '302':
+        '204':
           description: Email successfully deleted
         '403':
           description: Forbidden

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -155,6 +155,11 @@ paths:
       responses:
         '200':
           description: Returns the attachment data
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
         '403':
           description: Forbidden
         '404':

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -1,0 +1,489 @@
+openapi: 3.1.0
+info:
+  version: 5.1.0
+  title: Dispose Me
+  description: |-
+    Dispose Me is a simple AWS-hosted disposable email service with API capabilities.
+servers:
+  - url: https://{hostname}
+    variables:
+      hostname:
+        default: example.com
+        description: Your domain
+
+tags:
+  - name: Inbox
+    description: Inbox operations
+
+paths:
+  /inbox/{username}:
+    get:
+      summary: List emails in the inbox
+      description: List all emails sent to the inbox for a given username.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+            minLength: 3
+            maxLength: 25
+        - name: type
+          in: query
+          description: Output format
+          schema:
+            type: string
+            enum: ["json", "html"]
+            default: "html"
+        - name: sentAfter
+          in: query
+          description: Show only emails send after a date, represented as a Unix epoch time, with seconds precision.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Change maximal number of shown messages
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 100
+            default: 10
+      responses:
+        '200':
+          description: Return list of emails in the inbox
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailList'
+        '403':
+          description: Forbidden
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+  /inbox/{username}/{id}:
+    get:
+      summary: Show details of an email
+      description: Show the content of the email, including author, all recipients, subject, body, and information about attachments.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+        - name: id
+          in: path
+          description: Email ID
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Output format
+          schema:
+            type: string
+            enum: ["json", "html"]
+            default: "html"
+      responses:
+        '200':
+          description: Show email details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailDetails'
+        '403':
+          description: Forbidden
+        '404':
+          description: Email with given ID not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+  /inbox/{username}/{id}/attachment:
+    get:
+      summary: Download given attachment
+      description: Allows to download an attachment.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+        - name: id
+          in: path
+          description: Email ID
+          required: true
+          schema:
+            type: string
+        - name: filename
+          in: query
+          description: Filename of the attachment
+          required: true
+          schema:
+            type: string
+            examples: ["image.png"]
+      responses:
+        '200':
+          description: Returns the attachment data
+        '403':
+          description: Forbidden
+        '404':
+          description: Email with given ID not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '500':
+          description: Invalid email content or missing attachment
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+  /inbox/{username}/{id}/delete:
+    get:
+      summary: Delete given email
+      description: Allows to delete the email with given ID.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+        - name: id
+          in: path
+          description: Email ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Email successfully deleted
+        '403':
+          description: Forbidden
+        '404':
+          description: Email with given ID not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+  /inbox/{username}/{id}/download:
+    get:
+      summary: Download given email
+      description: Allows to download the email as an `.eml` file.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+        - name: id
+          in: path
+          description: Email ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Returns the content of the email
+        '403':
+          description: Forbidden
+        '404':
+          description: Email with given ID not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '500':
+          description: Invalid email content
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Error'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+  /inbox/{username}/latest:
+    get:
+      summary: Show details of the latest email
+      description: Show the content of the latest email, including author, all recipients, subject, body, and information about attachments.
+      tags:
+        - Inbox
+      parameters:
+        - name: username
+          in: path
+          description: The username
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-zA-Z0-9.\-_+]*$
+        - name: sentAfter
+          in: query
+          description: Show only email if it was send after a date, represented as a Unix epoch time, with seconds precision.
+          schema:
+            type: integer
+        - name: type
+          in: query
+          description: Output format
+          schema:
+            type: string
+            enum: ["json", "html"]
+            default: "html"
+      responses:
+        '200':
+          description: Show email details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailDetails'
+        '403':
+          description: Forbidden
+        '422':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+      security:
+        - api_token_header: []
+        - api_token_query: []
+        - api_token_cookie: []
+
+components:
+  schemas:
+    EmailItem:
+      type: object
+      retuired:
+        - id
+        - from
+        - subject
+        - received
+        - hasAttachments
+      properties:
+        id:
+          type: string
+          examples: ["223pfcdcrjar5jukmha0s67k7bdn1l1gidasbuo1"]
+        from:
+          type: string
+          format: email
+          examples: ["jane.doe@example.com"]
+        subject:
+          type: string
+          examples: ["Subject of the email"]
+        received:
+          type: string
+          format: date-time
+        hasAttachments:
+          type: boolean
+          examples: [false]
+    EmailList:
+      type: object
+      retuired:
+        - emails
+      properties:
+        emails:
+          type: array
+          items: 
+            $ref: '#/components/schemas/EmailItem'
+    EmailAddress:
+      type: object
+      retuired:
+        - address
+        - user
+        - host
+      properties:
+        address:
+          type: string
+          format: email
+          examples: ["john.doe@example.com"]
+        user:
+          type: string
+          examples: ["john.doe"]
+        host:
+          type: string
+          format: hostname
+          examples: ["example.com"]
+        displayName:
+          type: string
+          examples: ["John Doe"]
+    Attachment:
+      type: object
+      required:
+        - filename
+        - size
+        - contentType
+      properties:
+        filename:
+          type: string
+          examples: ["image.png"]
+        size:
+          type: integer
+          examples: [1337]
+        contentType:
+          type: string
+          examples: ["image/png"]
+    EmailDetails:
+      type: object
+      required:
+        - from
+        - to
+        - cc
+        - bcc
+        - subject
+        - body
+        - received
+        - attachments
+        - id
+      properties:
+        from:
+          $ref: '#/components/schemas/EmailAddress'
+        to:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailAddress'
+        cc:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailAddress'
+        bcc:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailAddress'
+        subject:
+          type: string
+          description: Subject of the email
+          examples: ["Subject of the email"]
+        body:
+          type: string
+          description: Body of the email
+          examples: ["Body of the email"]
+        received:
+          type: string
+          format: date-time
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attachment'
+        id:
+          type: string
+          examples: ["223pfcdcrjar5jukmha0s67k7bdn1l1gidasbuo1"]
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          examples: ["The page you are looking for was not found."]
+    ValidationError:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            required:
+              - type
+              - value
+              - msg
+              - path
+              - location
+            properties:
+              type:
+                type: string
+                examples: ["field"]
+              value:
+                type: string
+                examples: ["user^name"]
+              msg:
+                type: string
+                examples: ["Username may only contain letters, numbers, dots (.), hyphens (-), underscores (_), and plus signs (+)."]
+              path:
+                type: string
+                examples: ["username"]
+              location:
+                type: string
+                examples: ["params"]
+
+  securitySchemes:
+    api_token_header:
+      type: apiKey
+      name: x-api-key
+      in: header
+    api_token_query:
+      type: apiKey
+      name: x-api-key
+      in: query
+    api_token_cookie:
+      type: apiKey
+      name: x-api-key
+      in: cookie

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -245,6 +245,8 @@ paths:
       responses:
         '200':
           description: Returns the content of the email
+          content:
+            application/octet-stream: {}
         '403':
           description: Forbidden
         '404':
@@ -320,7 +322,7 @@ components:
   schemas:
     EmailItem:
       type: object
-      retuired:
+      required:
         - id
         - from
         - subject
@@ -345,7 +347,7 @@ components:
           examples: [false]
     EmailList:
       type: object
-      retuired:
+      required:
         - emails
       properties:
         emails:
@@ -354,7 +356,7 @@ components:
             $ref: '#/components/schemas/EmailItem'
     EmailAddress:
       type: object
-      retuired:
+      required:
         - address
         - user
         - host

--- a/lib/dispose-me-stack.ts
+++ b/lib/dispose-me-stack.ts
@@ -165,6 +165,11 @@ export class DisposeMeStack extends cdk.Stack {
       authorizer: apiAuthorizer,
       authorizationType: apigateway.AuthorizationType.CUSTOM,
     });
+    proxyResource.addMethod('DELETE', undefined, {
+      apiKeyRequired: privateAccess,
+      authorizer: apiAuthorizer,
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+    });
 
     // Point domain to the API Gateway
     new route53.ARecord(this, 'AliasRecord', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispose-me",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Dispose Me is a simple AWS-hosted disposable email service.",
   "author": "Kamil Dybicz",
   "license": "MIT",

--- a/service/api.ts
+++ b/service/api.ts
@@ -70,6 +70,11 @@ app.get(
   ...buildDeleteEmailValidationChain(),
   asyncHandler(inboxController.delete),
 );
+app.delete(
+  '/inbox/:username/:id/delete',
+  ...buildDeleteEmailValidationChain(),
+  asyncHandler(inboxController.delete),
+);
 app.get(
   '/inbox/:username/:id/download',
   ...buildDownloadEmailValidationChain(),

--- a/service/api/InboxController.ts
+++ b/service/api/InboxController.ts
@@ -159,9 +159,10 @@ export class InboxController {
       email = {
         ...parsedEmail,
         id,
-        attachments: parsedEmail.attachments.map(
-          (attachment) => ({ ...attachment, content: undefined }) as unknown as AttachmentDetails,
-        ),
+        attachments: parsedEmail.attachments.map((attachment) => ({
+          ...attachment,
+          content: undefined,
+        })),
       };
 
       if (type === 'html') {
@@ -314,9 +315,10 @@ export class InboxController {
         email = {
           ...parsedEmail,
           id: messageId,
-          attachments: parsedEmail.attachments.map(
-            (attachment) => ({ ...attachment, content: undefined }) as unknown as AttachmentDetails,
-          ),
+          attachments: parsedEmail.attachments.map((attachment) => ({
+            ...attachment,
+            content: undefined,
+          })),
         };
       }
     }

--- a/service/api/InboxController.ts
+++ b/service/api/InboxController.ts
@@ -268,6 +268,10 @@ export class InboxController {
     const normalizedUsername = normalizeUsername(username);
     const deletedFromDatabase = await this.emailDatabase.delete(normalizedUsername, id);
     if (deletedFromDatabase) {
+      if (req.method === 'DELETE') {
+        return res.status(204).end();
+      }
+
       return res.redirect(
         `/inbox/${username}?${new URLSearchParams(req.query as Record<string, string>)}`,
       );

--- a/service/api/InboxController.ts
+++ b/service/api/InboxController.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from 'express';
 import { type ValidationError, matchedData, validationResult } from 'express-validator';
 
 import { EmailDatabase } from '../tools/EmailDatabase';
-import { EmailParser, type ParsedEmail } from '../tools/EmailParser';
+import { type AttachmentDetails, EmailParser, type ParsedEmail } from '../tools/EmailParser';
 import { S3FileSystem } from '../tools/S3FileSystem';
 import { AUTH_COOKIE_KEY, AUTH_QUERY_KEY, REMEMBER_COOKIE_KEY } from '../tools/const';
 import { mapEmailDetailsListToFeed } from '../tools/feed';
@@ -159,6 +159,9 @@ export class InboxController {
       email = {
         ...parsedEmail,
         id,
+        attachments: parsedEmail.attachments.map(
+          (attachment) => ({ ...attachment, content: undefined }) as unknown as AttachmentDetails,
+        ),
       };
 
       if (type === 'html') {
@@ -307,6 +310,9 @@ export class InboxController {
         email = {
           ...parsedEmail,
           id: messageId,
+          attachments: parsedEmail.attachments.map(
+            (attachment) => ({ ...attachment, content: undefined }) as unknown as AttachmentDetails,
+          ),
         };
       }
     }

--- a/service/tools/EmailParser.ts
+++ b/service/tools/EmailParser.ts
@@ -24,7 +24,7 @@ export type AttachmentDetails = {
   filename?: string;
   size: number;
   contentType: string;
-  content: Buffer<ArrayBufferLike>;
+  content?: Buffer<ArrayBufferLike>;
 };
 
 export type ParsedEmail = {

--- a/test/service/api/InboxController.test.ts
+++ b/test/service/api/InboxController.test.ts
@@ -283,7 +283,7 @@ describe('InboxController', () => {
       MockedS3FileSystem.mockGetObject.mockResolvedValueOnce({
         Body: { transformToString: jest.fn().mockResolvedValueOnce('raw-email') },
       });
-      MockedEmailParser.mockParseEmail.mockResolvedValueOnce({ from: 'a', subject: 'b' });
+      MockedEmailParser.mockParseEmail.mockResolvedValueOnce(mockParsedEmail('a', 'b'));
 
       // when
       await controller.show(req, res);
@@ -306,7 +306,7 @@ describe('InboxController', () => {
       MockedS3FileSystem.mockGetObject.mockResolvedValueOnce({
         Body: { transformToString: jest.fn().mockResolvedValueOnce('raw-email') },
       });
-      MockedEmailParser.mockParseEmail.mockResolvedValueOnce({ from: 'a', subject: 'b' });
+      MockedEmailParser.mockParseEmail.mockResolvedValueOnce(mockParsedEmail('a', 'b'));
 
       // when
       await controller.show(req, res);
@@ -556,9 +556,16 @@ describe('InboxController', () => {
       MockedS3FileSystem.mockGetObject.mockResolvedValueOnce({
         Body: { transformToString: jest.fn().mockResolvedValueOnce('raw-email-data') },
       });
-      MockedEmailParser.mockParseEmail.mockResolvedValueOnce({
-        attachments: [{ filename: 'not-matching-name.txt' }],
-      });
+      MockedEmailParser.mockParseEmail.mockResolvedValueOnce(
+        mockParsedEmail('a', 'b', [
+          {
+            filename: 'not-matching-name.txt',
+            size: 1337,
+            contentType: 'plain/txt',
+            content: Buffer.from(''),
+          },
+        ]),
+      );
 
       // when
       await controller.downloadAttachment(req, res);
@@ -584,9 +591,16 @@ describe('InboxController', () => {
       // and
       const contentType = 'text/html; charset=utf-8';
       const content = Buffer.from('attachment data');
-      MockedEmailParser.mockParseEmail.mockResolvedValueOnce({
-        attachments: [{ filename, contentType, content }],
-      });
+      MockedEmailParser.mockParseEmail.mockResolvedValueOnce(
+        mockParsedEmail('a', 'b', [
+          {
+            filename,
+            size: content.byteLength,
+            contentType,
+            content,
+          },
+        ]),
+      );
 
       // when
       await controller.downloadAttachment(req, res);
@@ -746,7 +760,7 @@ describe('InboxController', () => {
         MockedS3FileSystem.mockGetObject.mockResolvedValueOnce({
           Body: { transformToString: jest.fn().mockResolvedValue('raw-email') },
         });
-        MockedEmailParser.mockParseEmail.mockResolvedValueOnce({ from: 'a', subject: 'b' });
+        MockedEmailParser.mockParseEmail.mockResolvedValueOnce(mockParsedEmail('a', 'b'));
 
         // when
         await controller.latest(req, res);
@@ -770,7 +784,7 @@ describe('InboxController', () => {
       MockedS3FileSystem.mockGetObject.mockResolvedValueOnce({
         Body: { transformToString: jest.fn().mockResolvedValue('raw-email') },
       });
-      MockedEmailParser.mockParseEmail.mockResolvedValueOnce({ from: 'a', subject: 'b' });
+      MockedEmailParser.mockParseEmail.mockResolvedValueOnce(mockParsedEmail('a', 'b'));
 
       // when
       await controller.latest(req, res);

--- a/test/service/api/InboxController.test.ts
+++ b/test/service/api/InboxController.test.ts
@@ -649,7 +649,7 @@ describe('InboxController', () => {
       expect(res.render).toHaveBeenCalledWith('pages/422', { errors });
     });
 
-    test('should redirect to inbox if deletion is successful', async () => {
+    test('should redirect to inbox if deletion is successful via GET request', async () => {
       // given
       const req = mockRequest<InboxEmailParams>({
         params: { username: USERNAME, id: MESSAGE_ID },
@@ -666,6 +666,25 @@ describe('InboxController', () => {
       expect(res.redirect).toHaveBeenCalledWith(
         `/inbox/${USERNAME}?${new URLSearchParams(req.query as Record<string, string>)}`,
       );
+    });
+
+    test('should redirect to inbox if deletion is successful via DELETE request', async () => {
+      // given
+      const req = mockRequest<InboxEmailParams>({
+        params: { username: USERNAME, id: MESSAGE_ID },
+        method: 'DELETE',
+      });
+      await validateRequest(req, buildDeleteEmailValidationChain());
+      // and
+      MockedEmailDatabase.mockDeleteEmail.mockResolvedValueOnce(true);
+
+      // when
+      await controller.delete(req, res);
+      // then
+      expect(MockedEmailDatabase.mockDeleteEmail).toHaveBeenCalledWith(USERNAME, MESSAGE_ID);
+      // and
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.end).toHaveBeenCalled();
     });
 
     test('should return 404 if deletion is unsuccessful', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,12 @@ import type { ValidationChain, ValidationError } from 'express-validator';
 import type { InboxRequest } from '../service/api/InboxController';
 import { AUTH_HEADER_KEY } from '../service/tools/const';
 import { EmailDatabase } from '../service/tools/EmailDatabase';
-import { EmailAddress, EmailParser, type ParsedEmail } from '../service/tools/EmailParser';
+import {
+  type AttachmentDetails,
+  EmailAddress,
+  EmailParser,
+  type ParsedEmail,
+} from '../service/tools/EmailParser';
 import { S3FileSystem } from '../service/tools/S3FileSystem';
 import { IncomingEmailProcessor } from '../service/processor/IncomingEmailProcessor';
 
@@ -94,7 +99,11 @@ export const MockedIncomingEmailProcessor = IncomingEmailProcessor as unknown as
   mockProcessEmail: jest.Mock;
 };
 
-export const mockParsedEmail = (from: string, subject: string): ParsedEmail => {
+export const mockParsedEmail = (
+  from: string,
+  subject: string,
+  attachments: AttachmentDetails[] = [],
+): ParsedEmail => {
   const fromAddress = new EmailAddress(from, from, 'example.com', 'Display Name');
   return {
     from: fromAddress,
@@ -104,6 +113,6 @@ export const mockParsedEmail = (from: string, subject: string): ParsedEmail => {
     subject,
     body: '',
     received: new Date('Thu, 22 May 2025 09:26:56 GMT'),
-    attachments: [],
+    attachments,
   };
 };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -30,6 +30,7 @@ export type RequestArgs<B> = {
   params?: Record<string, undefined | string>;
   cookies?: Record<string, string>;
   body?: B;
+  method?: 'GET' | 'POST' | 'DELETE';
 };
 
 export const validateRequest = async (
@@ -45,7 +46,7 @@ export const validateRequest = async (
 export const mockRequest = <P = Record<string, string>, B = any>(
   args?: RequestArgs<B>,
 ): InboxRequest<P, B> => {
-  const { query = {}, params = {}, cookies, body } = args ?? {};
+  const { query = {}, params = {}, cookies, body, method = 'GET' } = args ?? {};
   return {
     query,
     params,
@@ -59,6 +60,7 @@ export const mockRequest = <P = Record<string, string>, B = any>(
           : undefined,
     },
     body,
+    method,
   } as unknown as InboxRequest<P>;
 };
 


### PR DESCRIPTION
## 💡 What's Changed

[x] Adding `schema.yaml` with documentation of the API endpoints, and update `README.md`
[x] Fixing `/inbox/{username}/{id}` endpoint - making sure it doesn't return attachment data
[x] `/inbox/{username}/{id}` should work with `DELETE` request type and return HTTP `204` or `200` instead of `302`
[x] Add information about token authorization